### PR TITLE
fix bug on flops

### DIFF
--- a/splade/flops.py
+++ b/splade/flops.py
@@ -45,7 +45,7 @@ def flops(exp_dict: DictConfig):
                                     shuffle=False, num_workers=1)
 
     print("LOAD MODEL AND DOCUMENT INDEX")
-    evaluator = SparseIndexing(model=model, config=config, compute_stats=False, restore=True)
+    evaluator = SparseIndexing(model=model, config=config, compute_stats=False, restore=True, force_new=False)
     loaded_model = evaluator.model
     doc_index = evaluator.sparse_index
 

--- a/splade/tasks/transformer_evaluator.py
+++ b/splade/tasks/transformer_evaluator.py
@@ -19,10 +19,10 @@ class SparseIndexing(Evaluator):
     """sparse indexing
     """
 
-    def __init__(self, model, config, compute_stats=False, dim_voc=None, is_query=False, **kwargs):
+    def __init__(self, model, config, compute_stats=False, dim_voc=None, is_query=False, force_new=True,**kwargs):
         super().__init__(model, config, **kwargs)
         self.index_dir = config["index_dir"] if config is not None else None
-        self.sparse_index = IndexDictOfArray(self.index_dir, dim_voc=dim_voc, force_new=True)
+        self.sparse_index = IndexDictOfArray(self.index_dir, dim_voc=dim_voc, force_new=force_new)
         self.compute_stats = compute_stats
         self.is_query = is_query
         if self.compute_stats:


### PR DESCRIPTION
Fix a bug on the FLOPS computation (#21 ) that has been here for a while now... 

The bug is that the current version doesn't load the document index, but starts from new. Introducing a parameter to the SparseIndexing allows avoiding the bug.