### PR TITLE
fix: Update amp.py assertion

### DIFF
--- a/splade/tasks/amp.py
+++ b/splade/tasks/amp.py
@@ -20,11 +20,10 @@ class NullContextManager(object):
 
 class MixedPrecisionManager:
     def __init__(self, activated):
-        assert (not activated) or (not PyTorch_over_1_6), "Cannot use AMP for PyTorch version < 1.6"
-
         print("Using FP16:", activated)
         self.activated = activated
         if self.activated:
+            assert not PyTorch_over_1_6, "Cannot use AMP for PyTorch version < 1.6"
             self.scaler = torch.cuda.amp.GradScaler()
 
     def context(self):

--- a/splade/tasks/amp.py
+++ b/splade/tasks/amp.py
@@ -20,7 +20,7 @@ class NullContextManager(object):
 
 class MixedPrecisionManager:
     def __init__(self, activated):
-        assert (not activated) or PyTorch_over_1_6, "Cannot use AMP for PyTorch version < 1.6"
+        assert (not activated) or (not PyTorch_over_1_6), "Cannot use AMP for PyTorch version < 1.6"
 
         print("Using FP16:", activated)
         self.activated = activated


### PR DESCRIPTION
The assertion outputs `"Cannot use AMP for PyTorch version < 1.6"` however, the way the `PyTorch_over_1_6` check is handled, is contrary to this, causing it to fail with Pytorch version 1.11 (Included in the conda env)